### PR TITLE
[TW-20] Increase speed counter TweetCard

### DIFF
--- a/apps/nextjs/src/components/Cards/TweetCard/TweetCard.tsx
+++ b/apps/nextjs/src/components/Cards/TweetCard/TweetCard.tsx
@@ -39,6 +39,11 @@ export interface TweetCardProps {
    * The number of views at the end of the count animation.
    */
   viewCount?: number;
+  
+  /**
+   * The number in milliseconds of speed the counter.
+   */
+  speedCount?: number;
 }
 
 export const TweetCard = ({
@@ -49,6 +54,7 @@ export const TweetCard = ({
   tweetText,
   isTypingAnimationEnabled = false,
   viewCount = 20,
+  speedCount = 25
 }: TweetCardProps) => {
   const classes = {
     container: cn(
@@ -107,7 +113,7 @@ export const TweetCard = ({
         </div>
         <div className="items max-[360px]:hidden flex items-center gap-2">
           <Icon icon={IconCatalog.twitterView} isSolid={true} className="w-4" />
-          <Counter start={0} end={viewCount} speed={25} />
+          <Counter start={0} end={viewCount} speed={speedCount} />
         </div>
       </div>
     </div>

--- a/apps/nextjs/src/pages/index.tsx
+++ b/apps/nextjs/src/pages/index.tsx
@@ -68,6 +68,7 @@ const Landing: NextPage = () => {
           <div>
             <div className="mb-2 text-xl font-medium text-slate-50">Output Tweet</div>
             <TweetCard
+              speedCount={1}
               className="shadow-center animation-delay-1000 opacity-0 shadow-secondary-400 md:min-h-[400px] lg:min-h-[300px]"
               commentCount={32}
               likeCount={50}


### PR DESCRIPTION
## Changes Made 🎉

- feat: Changed the speed of the view counter on the TweetCard component to increase its speed. Previously, the duration was set to 25 milliseconds. The speed has been increased to 1 millisecond so that users can quickly see the total number of views, with this change the duration is around 10 seconds.


### Describe Changes

- Created a new prop called speedCount for the TweetCard component to control the speed of the view counter.
- The default value of speedCount has been set to 25.

## Related Issue(s)

- 20


